### PR TITLE
JCS-193: [CDI] [JCache annotations] Set configuration more friendly.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ target
 .settings
 .java-version
 .idea/
+
+*.log

--- a/commons-jcs-jcache/src/main/java/org/apache/commons/jcs/jcache/JCSCachingManager.java
+++ b/commons-jcs-jcache/src/main/java/org/apache/commons/jcs/jcache/JCSCachingManager.java
@@ -18,6 +18,7 @@
  */
 package org.apache.commons.jcs.jcache;
 
+import static org.apache.commons.jcs.jcache.JCSCachingProvider.JCS_URI_PREFFIX;
 import org.apache.commons.jcs.engine.control.CompositeCacheManager;
 import org.apache.commons.jcs.jcache.lang.Subsitutor;
 import org.apache.commons.jcs.jcache.proxy.ClassLoaderAwareCache;
@@ -45,15 +46,15 @@ public class JCSCachingManager implements CacheManager
     private static final String DEFAULT_CONFIG =
         "jcs.default=DC\n" +
         "jcs.default.cacheattributes=org.apache.commons.jcs.engine.CompositeCacheAttributes\n" +
-        "jcs.default.cacheattributes.MaxObjects=200001\n" +
+        "jcs.default.cacheattributes.MaxObjects=100\n" +
         "jcs.default.cacheattributes.MemoryCacheName=org.apache.commons.jcs.engine.memory.lru.LRUMemoryCache\n" +
         "jcs.default.cacheattributes.UseMemoryShrinker=true\n" +
-        "jcs.default.cacheattributes.MaxMemoryIdleTimeSeconds=3600\n" +
-        "jcs.default.cacheattributes.ShrinkerIntervalSeconds=60\n" +
+        "jcs.default.cacheattributes.MaxMemoryIdleTimeSeconds=7200\n" +
+        "jcs.default.cacheattributes.ShrinkerIntervalSeconds=30\n" +
         "jcs.default.elementattributes=org.apache.commons.jcs.engine.ElementAttributes\n" +
-        "jcs.default.elementattributes.IsEternal=false\n" +
-        "jcs.default.elementattributes.MaxLife=700\n" +
-        "jcs.default.elementattributes.IdleTime=1800\n" +
+        "jcs.default.elementattributes.IsEternal=true\n" +
+        "jcs.default.elementattributes.MaxLife=-1\n" +
+        "jcs.default.elementattributes.IdleTime=-1\n" +
         "jcs.default.elementattributes.IsSpool=true\n" +
         "jcs.default.elementattributes.IsRemote=true\n" +
         "jcs.default.elementattributes.IsLateral=true\n";
@@ -100,10 +101,10 @@ public class JCSCachingManager implements CacheManager
     private Properties readConfig(final URI uri, final ClassLoader loader, final Properties properties) {
         final Properties props = new Properties();
         try {
-            if (JCSCachingProvider.DEFAULT_URI.toString().equals(uri.toString()) || uri.toURL().getProtocol().equals("jcs"))
+            if (JCSCachingProvider.DEFAULT_URI.toString().equals(uri.toString()) 
+                || uri.toString().startsWith(JCS_URI_PREFFIX))
             {
-
-                final Enumeration<URL> resources = loader.getResources(uri.getPath());
+                final Enumeration<URL> resources = loader.getResources(uri.toString().substring(JCS_URI_PREFFIX.length()));
                 if (!resources.hasMoreElements()) // default
                 {
                     props.load(new ByteArrayInputStream(DEFAULT_CONFIG.getBytes("UTF-8")));

--- a/commons-jcs-jcache/src/main/java/org/apache/commons/jcs/jcache/JCSCachingProvider.java
+++ b/commons-jcs-jcache/src/main/java/org/apache/commons/jcs/jcache/JCSCachingProvider.java
@@ -30,6 +30,7 @@ import java.util.concurrent.ConcurrentMap;
 public class JCSCachingProvider implements CachingProvider
 {
     public static final URI DEFAULT_URI = URI.create("jcs://jcache.ccf");
+    public static final String JCS_URI_PREFFIX="jcs://";
 
     private final ConcurrentMap<ClassLoader, ConcurrentMap<URI, CacheManager>> cacheManagersByLoader = new ConcurrentHashMap<ClassLoader, ConcurrentMap<URI, CacheManager>>();
 

--- a/commons-jcs-jcache/src/main/java/org/apache/commons/jcs/jcache/cdi/CDIJCacheHelper.java
+++ b/commons-jcs-jcache/src/main/java/org/apache/commons/jcs/jcache/cdi/CDIJCacheHelper.java
@@ -371,7 +371,7 @@ public class CDIJCacheHelper
                 return (T) defaultCacheManager();
             }
             if (ConfigurationResolver.class == type) {
-                return (T) defaultConficutationResolver();
+                return (T) defaultConfigurationResolver();
             }
             return null;
         }
@@ -397,7 +397,7 @@ public class CDIJCacheHelper
         }
     }   
     
-    private ConfigurationResolver defaultConficutationResolver()
+    private ConfigurationResolver defaultConfigurationResolver()
     {
         return new ConfigurationResolver()
         {                    

--- a/commons-jcs-jcache/src/main/java/org/apache/commons/jcs/jcache/cdi/CacheResolverFactoryImpl.java
+++ b/commons-jcs-jcache/src/main/java/org/apache/commons/jcs/jcache/cdi/CacheResolverFactoryImpl.java
@@ -32,12 +32,14 @@ import java.lang.annotation.Annotation;
 public class CacheResolverFactoryImpl implements CacheResolverFactory
 {
     private final CacheManager cacheManager;
-    private final CachingProvider provider;
+    private final ConfigurationResolver configurationResolver;
 
-    public CacheResolverFactoryImpl()
+    public CacheResolverFactoryImpl(CacheManager cacheManager,ConfigurationResolver configurationResolver)
     {
-        provider = Caching.getCachingProvider();
-        cacheManager = provider.getCacheManager(provider.getDefaultURI(), provider.getDefaultClassLoader());
+        this.cacheManager=cacheManager;
+        this.configurationResolver=configurationResolver;
+//        provider = Caching.getCachingProvider();
+//        cacheManager = provider.getCacheManager(provider.getDefaultURI(), provider.getDefaultClassLoader());
     }
 
     @Override
@@ -69,13 +71,13 @@ public class CacheResolverFactoryImpl implements CacheResolverFactory
 
     private Cache<?, ?> createCache(final String exceptionCacheName)
     {
-        cacheManager.createCache(exceptionCacheName, new MutableConfiguration<Object, Object>().setStoreByValue(false));
+        cacheManager.createCache(exceptionCacheName,configurationResolver.get( exceptionCacheName ));
         return cacheManager.getCache(exceptionCacheName);
     }
 
     public void release()
     {
         cacheManager.close();
-        provider.close();
+//        provider.close();
     }
 }

--- a/commons-jcs-jcache/src/main/java/org/apache/commons/jcs/jcache/cdi/CacheResolverFactoryImpl.java
+++ b/commons-jcs-jcache/src/main/java/org/apache/commons/jcs/jcache/cdi/CacheResolverFactoryImpl.java
@@ -38,8 +38,6 @@ public class CacheResolverFactoryImpl implements CacheResolverFactory
     {
         this.cacheManager=cacheManager;
         this.configurationResolver=configurationResolver;
-//        provider = Caching.getCachingProvider();
-//        cacheManager = provider.getCacheManager(provider.getDefaultURI(), provider.getDefaultClassLoader());
     }
 
     @Override

--- a/commons-jcs-jcache/src/main/java/org/apache/commons/jcs/jcache/cdi/ConfigurationResolver.java
+++ b/commons-jcs-jcache/src/main/java/org/apache/commons/jcs/jcache/cdi/ConfigurationResolver.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.commons.jcs.jcache.cdi;
+
+import javax.cache.configuration.Configuration;
+
+public interface ConfigurationResolver
+{
+    Configuration<Object,Object> get(String cacheName);
+}


### PR DESCRIPTION
Right now configuration of caches used by JCache annotation interceptors
is almost hardcoded or needs to be always set in the annotations.

This development goes wants be able to set up those caches always
througt bean injection.