### PR TITLE
JCS-209 - Use Collections.singletonList insteadof Arrays.asList when there be only with few arguments

### DIFF
--- a/commons-jcs-core/src/main/java/org/apache/commons/jcs3/auxiliary/lateral/LateralCacheNoWait.java
+++ b/commons-jcs-core/src/main/java/org/apache/commons/jcs3/auxiliary/lateral/LateralCacheNoWait.java
@@ -403,11 +403,9 @@ public class LateralCacheNoWait<K, V>
         final IStats stats = new Stats();
         stats.setTypeName( "Lateral Cache No Wait" );
 
-        final ArrayList<IStatElement<?>> elems = new ArrayList<>();
-
         // get the stats from the event queue too
         final IStats eqStats = this.eventQueue.getStatistics();
-        elems.addAll(eqStats.getStatElements());
+        final ArrayList<IStatElement<?>> elems = new ArrayList<>(eqStats.getStatElements());
 
         elems.add(new StatElement<>( "Get Count", Integer.valueOf(this.getCount) ) );
         elems.add(new StatElement<>( "Remove Count", Integer.valueOf(this.removeCount) ) );

--- a/commons-jcs-core/src/main/java/org/apache/commons/jcs3/engine/CacheWatchRepairable.java
+++ b/commons-jcs-core/src/main/java/org/apache/commons/jcs3/engine/CacheWatchRepairable.java
@@ -20,7 +20,7 @@ package org.apache.commons.jcs3.engine;
  */
 
 import java.io.IOException;
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -89,7 +89,7 @@ public class CacheWatchRepairable
     {
         // Record the added cache listener locally, regardless of whether the
         // remote add-listener operation succeeds or fails.
-        cacheMap.computeIfAbsent(cacheName, key -> new CopyOnWriteArraySet<>(Arrays.asList(obj)));
+        cacheMap.computeIfAbsent(cacheName, key -> new CopyOnWriteArraySet<>(Collections.singletonList(obj)));
 
         log.info( "Adding listener to cache watch. ICacheListener = {0} | "
                 + "ICacheObserver = {1} | cacheName = {2}", obj, cacheWatch,

--- a/commons-jcs-jcache/src/main/java/org/apache/commons/jcs3/jcache/ExpiryAwareCache.java
+++ b/commons-jcs-jcache/src/main/java/org/apache/commons/jcs3/jcache/ExpiryAwareCache.java
@@ -19,6 +19,7 @@
 package org.apache.commons.jcs3.jcache;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Map;
 
 import javax.cache.Cache;
@@ -48,7 +49,7 @@ public class ExpiryAwareCache<A, B> extends CompositeCache<A, B>
         super.doExpires(element);
         for (final JCSListener<A, B> listener : listeners.values())
         {
-            listener.onExpired(Arrays.<CacheEntryEvent<? extends A, ? extends B>> asList(new JCSCacheEntryEvent<>(
+            listener.onExpired(Collections.<CacheEntryEvent<? extends A, ? extends B>>singletonList(new JCSCacheEntryEvent<>(
                     cacheRef, EventType.REMOVED, null, element.getKey(), element.getVal())));
         }
     }

--- a/commons-jcs-jcache/src/main/java/org/apache/commons/jcs3/jcache/JCSCache.java
+++ b/commons-jcs-jcache/src/main/java/org/apache/commons/jcs3/jcache/JCSCache.java
@@ -24,6 +24,7 @@ import static org.apache.commons.jcs3.jcache.serialization.Serializations.copy;
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -382,12 +383,12 @@ public class JCSCache<K, V> implements Cache<K, V>
             {
                 if (created)
                 {
-                    listener.onCreated(Arrays.<CacheEntryEvent<? extends K, ? extends V>> asList(new JCSCacheEntryEvent<>(this,
+                    listener.onCreated(Collections.<CacheEntryEvent<? extends K, ? extends V>>singletonList(new JCSCacheEntryEvent<>(this,
                             EventType.CREATED, null, key, value)));
                 }
                 else
                 {
-                    listener.onUpdated(Arrays.<CacheEntryEvent<? extends K, ? extends V>> asList(new JCSCacheEntryEvent<>(this,
+                    listener.onUpdated(Collections.<CacheEntryEvent<? extends K, ? extends V>>singletonList(new JCSCacheEntryEvent<>(this,
                             EventType.UPDATED, old, key, value)));
                 }
             }
@@ -418,7 +419,7 @@ public class JCSCache<K, V> implements Cache<K, V>
         delegate.remove(cacheKey);
         for (final JCSListener<K, V> listener : listeners.values())
         {
-            listener.onExpired(Arrays.<CacheEntryEvent<? extends K, ? extends V>> asList(new JCSCacheEntryEvent<>(this,
+            listener.onExpired(Collections.<CacheEntryEvent<? extends K, ? extends V>>singletonList(new JCSCacheEntryEvent<>(this,
                     EventType.REMOVED, null, cacheKey, elt.getVal())));
         }
     }
@@ -477,7 +478,7 @@ public class JCSCache<K, V> implements Cache<K, V>
         final boolean remove = v != null;
         for (final JCSListener<K, V> listener : listeners.values())
         {
-            listener.onRemoved(Arrays.<CacheEntryEvent<? extends K, ? extends V>> asList(new JCSCacheEntryEvent<>(this,
+            listener.onRemoved(Collections.<CacheEntryEvent<? extends K, ? extends V>>singletonList(new JCSCacheEntryEvent<>(this,
                     EventType.REMOVED, null, key, value)));
         }
         if (remove && statisticsEnabled)


### PR DESCRIPTION
* Use Collections.singletonList insteadof Arrays.asList when there be only with few arguments
* Use empty array