### PR TITLE
Improve performance in the Test phase

### DIFF
--- a/commons-jcs-core/pom.xml
+++ b/commons-jcs-core/pom.xml
@@ -135,7 +135,7 @@
           <version>${commons.surefire.version}</version>
           <configuration>
             <argLine>-Xmx256m</argLine>
-            <forkCount>1</forkCount>
+            <forkCount>1.5C</forkCount>
             <reuseForks>false</reuseForks>
             <includes>
               <include>**/*UnitTest.java</include>


### PR DESCRIPTION

Maven will run all tests in a single forked VM by default. This can be problematic if there are a lot of tests or some very memory-hungry ones. We can fork more test VM by setting `<fork>1.5C</fork>`.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
