### PR TITLE
Added missing @Deprecated annotations

### DIFF
--- a/auxiliary-builds/jdk14/src/java/org/apache/commons/jcs/auxiliary/lateral/LateralCacheFactory.java
+++ b/auxiliary-builds/jdk14/src/java/org/apache/commons/jcs/auxiliary/lateral/LateralCacheFactory.java
@@ -42,6 +42,7 @@ import java.util.StringTokenizer;
  *
  * @deprecated use the new TYPE specific lateral factories.
  */
+@Deprecated
 public class LateralCacheFactory
     extends LateralCacheAbstractFactory
 {

--- a/auxiliary-builds/jdk14/src/java/org/apache/commons/jcs/auxiliary/lateral/LateralCacheManager.java
+++ b/auxiliary-builds/jdk14/src/java/org/apache/commons/jcs/auxiliary/lateral/LateralCacheManager.java
@@ -51,6 +51,7 @@ import java.util.Map;
  *
  * @deprecated use individual cache managers
  */
+@Deprecated
 public class LateralCacheManager
     implements ILateralCacheManager
 {

--- a/auxiliary-builds/jdk14/src/java/org/apache/commons/jcs/auxiliary/lateral/javagroups/LateralJGCacheFactory.java
+++ b/auxiliary-builds/jdk14/src/java/org/apache/commons/jcs/auxiliary/lateral/javagroups/LateralJGCacheFactory.java
@@ -41,6 +41,7 @@ import java.util.ArrayList;
  *
  * @deprecated use the new TYPE specific lateral factories.
  */
+@Deprecated
 public class LateralJGCacheFactory
     extends LateralCacheAbstractFactory
 {

--- a/auxiliary-builds/jdk14/src/java/org/apache/commons/jcs/auxiliary/lateral/javagroups/LateralJGCacheManager.java
+++ b/auxiliary-builds/jdk14/src/java/org/apache/commons/jcs/auxiliary/lateral/javagroups/LateralJGCacheManager.java
@@ -55,6 +55,7 @@ import java.util.Map;
  *
  * @deprecated use individual cache managers
  */
+@Deprecated
 public class LateralJGCacheManager
     extends LateralCacheAbstractManager
 {


### PR DESCRIPTION
These annotations helpfully to prevent usage of deprecated API. For example: developer can see crossed out method/field name if this item is deprecated.