### PR TITLE
Removed double null check with instance operator

### DIFF
--- a/auxiliary-builds/jdk14/src/java/org/apache/commons/jcs/auxiliary/lateral/javagroups/LateralJGReceiver.java
+++ b/auxiliary-builds/jdk14/src/java/org/apache/commons/jcs/auxiliary/lateral/javagroups/LateralJGReceiver.java
@@ -89,7 +89,7 @@ public class LateralJGReceiver
                 try
                 {
                     Object obj = javagroups.receive( 0 );
-                    if ( obj != null && obj instanceof org.jgroups.Message )
+                    if ( obj instanceof org.jgroups.Message )
                     {
                         mes = (Message) obj;
                         if ( log.isDebugEnabled() )

--- a/commons-jcs-core/src/main/java/org/apache/commons/jcs3/auxiliary/remote/RemoteCache.java
+++ b/commons-jcs-core/src/main/java/org/apache/commons/jcs3/auxiliary/remote/RemoteCache.java
@@ -141,7 +141,7 @@ public class RemoteCache<K, V>
         log.error( message, ex );
 
         // we should not switch if the existing is a zombie.
-        if ( getRemoteCacheService() == null || !( getRemoteCacheService() instanceof ZombieCacheServiceNonLocal ) )
+        if ( !( getRemoteCacheService() instanceof ZombieCacheServiceNonLocal ) )
         {
             // TODO make configurable
             setRemoteCacheService( new ZombieCacheServiceNonLocal<>( getRemoteCacheAttributes().getZombieQueueMaxSize() ) );

--- a/commons-jcs-sandbox/yajcache/src/main/java/org/apache/commons/jcs/yajcache/core/CacheManager.java
+++ b/commons-jcs-sandbox/yajcache/src/main/java/org/apache/commons/jcs/yajcache/core/CacheManager.java
@@ -73,7 +73,7 @@ public enum CacheManager {
     public ICacheSafe getSafeCache(@NonNullable String name) {
         ICache c = this.getCache(name);
 
-        if (c == null || !(c instanceof ICacheSafe))
+        if (!(c instanceof ICacheSafe))
             return null;
         return (ICacheSafe)c;
     }


### PR DESCRIPTION
Sometimes found usage of instance operator with variable superflous check for null. But also there is not only variables.