### PR TITLE
Fix put time in JCSCache.put(K, V)

### DIFF
--- a/commons-jcs3-jcache/src/main/java/org/apache/commons/jcs3/jcache/JCSCache.java
+++ b/commons-jcs3-jcache/src/main/java/org/apache/commons/jcs3/jcache/JCSCache.java
@@ -752,7 +752,7 @@ public class JCSCache<K, V> implements Cache<K, V>
             if (statisticsEnabled)
             {
                 statistics.increasePuts(1);
-                statistics.addPutTime(System.currentTimeMillis() - start);
+                statistics.addPutTime(Times.now(false) - start);
             }
         } else if (!created)
         {


### PR DESCRIPTION
The start and end value have different units and do not match. End time is in milliseconds, start time in microseconds which leads to wrong statistics.