### PR TITLE
JCS-242:  Fix lateral cache in error state

### DIFF
--- a/commons-jcs3-core/src/main/java/org/apache/commons/jcs3/auxiliary/lateral/LateralCacheMonitor.java
+++ b/commons-jcs3-core/src/main/java/org/apache/commons/jcs3/auxiliary/lateral/LateralCacheMonitor.java
@@ -72,6 +72,19 @@ public class LateralCacheMonitor extends AbstractAuxiliaryCacheMonitor
     {
         this.caches.put(cache.getCacheName(), (LateralCacheNoWait<Object, Object>)cache);
 
+        // Fix a cache where an exception occurred before it was added to this monitor.
+        // For instance, where a cache failed to connect to lateral TCP server.
+        if (cache.getStatus() == CacheStatus.ERROR) {
+            if (getState() == Thread.State.NEW)
+            {
+                // no need to signal trigger if monitor hasn't started
+                allright.compareAndSet(true, false);
+            }
+            else {
+                notifyError();
+            }
+        }
+
         // if not yet started, go ahead
         if (getState() == Thread.State.NEW)
         {


### PR DESCRIPTION

Update the Cache Monitor so that it can fix a cache that experienced an exception (and has fallen back to the zombie cache) before it was added to the monitor.  For instance a lateral cache may be in an error state after failing to connect to a TCP server during initialization. 


- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request.
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best-practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
